### PR TITLE
feat: upgrade to buildpack v4

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,12 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>renovatebot/presets-internal"],
-  "packageRules": [
-    {
-      "packageNames": ["renovate"],
-      "extends": ["schedule:weekly"],
-      "automerge": true,
-      "separateMinorPatch": false
-    }
-  ]
+  "extends": ["github>renovatebot/.github"]
 }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,5 +33,5 @@ jobs:
 
       - uses: actions/upload-artifact@v2.2.2
         with:
-          name: ${{ matrix.flavor }}
+          name: ${{ env.FLAVOR }}
           path: .cache/*.tar.xz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,16 +8,12 @@ on:
 
   pull_request:
 
+env:
+  FLAVOR: focal
+
 jobs:
   build:
     runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        flavor: [bionic, focal]
-
-    env:
-      FLAVOR: ${{ matrix.flavor }}
 
     steps:
       - uses: actions/checkout@v2.3.4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
   pull_request:
 
 env:
-  FLAVOR: focal
+  FLAVOR: focal # build target, name required by binary-builder
 
 jobs:
   build:

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,9 @@
 #--------------------------------------
 FROM renovate/buildpack:4 as build
 
-USER root
+# build target, name required by binary-builder
+ARG FLAVOR
+RUN . /etc/os-release; [ "${VERSION_CODENAME}" == "${FLAVOR}" ] || exit 55
 
 ENTRYPOINT [ "docker-entrypoint.sh", "builder.sh" ]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,8 @@
-ARG FLAVOR=latest
-
 
 #--------------------------------------
 # base image
 #--------------------------------------
-FROM renovate/buildpack:3-${FLAVOR} as build
+FROM renovate/buildpack:4 as build
 
 USER root
 
@@ -23,7 +21,3 @@ RUN set -ex; \
   rm -rf ruby-build;
 
 COPY bin /usr/local/bin
-
-# rebuild trigger
-# renovate: datasource=ruby-version depName=ruby versioning=ruby
-ENV RUBY_VERSION=3.0.0

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ![build](https://github.com/renovatebot/ruby/workflows/build/badge.svg)
+![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/renovatebot/ruby)
+![GitHub](https://img.shields.io/github/license/renovatebot/ruby)
 
-# ruby-builds
+# Renovate Ruby releases
 
-prebuild ruby releases
+Prebuild Ruby releases used by [renovatebot/buildpack](https://github.com/renovatebot/buildpack).

--- a/builder.json
+++ b/builder.json
@@ -1,5 +1,6 @@
 {
   "image": "ruby",
+  "depName": "ruby",
   "datasource": "ruby-version",
   "versioning": "ruby",
   "startVersion": "2.5.0",

--- a/builder.json
+++ b/builder.json
@@ -1,5 +1,7 @@
 {
   "image": "ruby",
+  "datasource": "ruby-version",
+  "versioning": "ruby",
   "startVersion": "2.5.0",
   "ignoredVersions": ["2.5.0-preview1", "2.5.0-rc1", "2.5.2"]
 }

--- a/renovate.Dockerfile
+++ b/renovate.Dockerfile
@@ -1,0 +1,11 @@
+FROM scratch
+
+
+# rebuild trigger
+# renovate: datasource=ruby-version depName=ruby versioning=ruby
+ENV RUBY_VERSION=2.7.2
+
+
+# rebuild trigger
+# renovate: datasource=ruby-version depName=ruby versioning=ruby
+ENV RUBY_VERSION=3.0.0

--- a/renovate.Dockerfile
+++ b/renovate.Dockerfile
@@ -1,7 +1,11 @@
+#-------------------------
+# renovate rebuild trigger
+#-------------------------
+
+# makes lint happy
 FROM scratch
 
 
-# rebuild trigger
 # renovate: datasource=ruby-version depName=ruby versioning=ruby
 ENV RUBY_VERSION=2.7.2
 


### PR DESCRIPTION
We should have `docker-ruby` and `docker-renovate`  on focal before

With this pr we only build `focal` releases for new ruby versions